### PR TITLE
feat(ex-emails): Enable sending emails to adimns on exceptions

### DIFF
--- a/HadithHouseWebsite/HadithHouseWebsite/settings.py
+++ b/HadithHouseWebsite/HadithHouseWebsite/settings.py
@@ -162,7 +162,7 @@ LOGGING = {
       'propagate': True,
     },
     'django.request': {
-      'handlers': ['django_requests_log_file'],
+      'handlers': ['django_requests_log_file', 'mail_admins'],
       'level': 'ERROR',
       'propagate': False,
     },


### PR DESCRIPTION
This feature got disabled after we enabled logging because we didn't
use the `mail_admin` handler in the `django.request` logger. I can
see that at some point we should probably remove it again because
we might start receiving unnecessary emails, but for now I guess it
is good to have it to be alerted when a problem happens.

#157