### PR TITLE
feat(textprocessing): Add reformat_text() method

### DIFF
--- a/HadithHouseWebsite/hadiths/tests.py
+++ b/HadithHouseWebsite/hadiths/tests.py
@@ -6,11 +6,12 @@ from hadiths.models import Person
 class PersonTestCase(TestCase):
   def test_pre_save(self):
     p = Person()
-    p.display_name = 'رافِد'
-    p.full_name = 'رافِد خالِد'
-    p.brief_desc = 'مُبَرْمِج'
+    p.display_name = 'إخْتِبار إزَاْلة عَلامات التَشْكيل'
+    p.full_name = 'إخْتِبار إزَاْلة عَلامات التَشْكيل'
+    p.brief_desc ='إخْتِبار إزَاْلة عَلامات التَشْكيل'
     p.save()
 
-    self.assertEqual(p.simple_display_name, 'رافد')
-    self.assertEqual(p.simple_full_name, 'رافد خالد')
-    self.assertEqual(p.simple_brief_desc, 'مبرمج')
+    self.assertEqual('اختبار ازالة علامات التشكيل', p.simple_display_name, )
+    self.assertEqual('اختبار ازالة علامات التشكيل', p.simple_full_name, )
+    self.assertEqual('اختبار ازالة علامات التشكيل', p.simple_brief_desc, )
+

--- a/HadithHouseWebsite/textprocessing/arabic.py
+++ b/HadithHouseWebsite/textprocessing/arabic.py
@@ -7,13 +7,32 @@ def remove_arabic_diactrictics(input):
   return re.sub(u'[\u064B-\u0652]', '', input, flags=re.MULTILINE)
 
 
-def unify_alif_letters(input):
+def unify_alef_letters(input):
   if input is None:
     return None
-  return re.sub(u'[\u0622\u0623\u0625]', u'\u0627', input, flags=re.MULTILINE)
+  # Source: "Arabic script in Unicode" at Wikipedia
+  alef = '\u0627'
+  alef_with_madda = '\u0622'
+  alef_with_hamza = '\u0623'
+  alef_with_hamza_below = '\u0625'
+  alef_wasla = '\u0671'
+  alef_with_wavy_hamza = '\u0672'
+  alef_with_wavy_hamza_below = '\u0673'
+  alef_high_hamza_alef = '\u0675'
+  regex = '[' + ''.join([
+    alef_with_madda,
+    alef_with_hamza,
+    alef_with_hamza_below,
+    alef_wasla,
+    alef_with_wavy_hamza,
+    alef_with_wavy_hamza_below,
+    alef_high_hamza_alef
+  ]) + ']'
+  return re.sub(regex, u'\u0627', input, flags=re.MULTILINE)
 
 
 def simplify_arabic_text(input):
   if input is None:
     return None
-  return unify_alif_letters(remove_arabic_diactrictics(input))
+  return unify_alef_letters(remove_arabic_diactrictics(input))
+

--- a/HadithHouseWebsite/textprocessing/generic.py
+++ b/HadithHouseWebsite/textprocessing/generic.py
@@ -8,7 +8,7 @@ def multiline_to_singleline(text):
   :param text: The text to convert.
   :return: The single-line version of the text.
   """
-  return re.sub('\s{2,}', ' ', text)
+  return re.sub('\s+', ' ', text)
 
 
 def remove_brackets_whitespaces(text):
@@ -18,4 +18,21 @@ def remove_brackets_whitespaces(text):
   :param text: The text to process.
   :return: The processed texts.
   """
-  return re.sub(r'\(\s*(\S*)\s*\)', r'(\1)', text)
+  return re.sub(r'\(\s*', '(', re.sub(r'\s*\)', ')', text))
+
+
+def reformat_text(input):
+  """
+  Re-formats the given text according to the following rules:
+  - Unnecessary whitespaces are removed.
+  - The text is converted into a single-line.
+  - Unnecessary whitespaces after opening brackets and before closing brackets
+    are removed.
+  :param input: The unformatted text.
+  :return: The formatted text.
+  """
+  return remove_brackets_whitespaces(
+    multiline_to_singleline(
+      input
+    )
+  ).strip()

--- a/HadithHouseWebsite/textprocessing/tests.py
+++ b/HadithHouseWebsite/textprocessing/tests.py
@@ -1,11 +1,42 @@
 from django.test import TestCase
 from django.test.testcases import SimpleTestCase
 
-from textprocessing.generic import multiline_to_singleline
+from textprocessing.arabic import remove_arabic_diactrictics, unify_alef_letters
+from textprocessing.generic import multiline_to_singleline, remove_brackets_whitespaces, reformat_text
 
 
 class GenericTestCase(SimpleTestCase):
   def test_multiline_to_singleline(self):
-    input = 'My name is   Rafid  Khalid'
+    input = 'My name is \n  Rafid \r Khalid'
     output = multiline_to_singleline(input)
-    self.assertEqual(output, 'My name is Rafid Khalid')
+    self.assertEqual('My name is Rafid Khalid', output)
+
+  def test_remove_brackets_whitespaces(self):
+    input = 'This is a text with (  incorrect whitespaces between brackets   ).'
+    output = remove_brackets_whitespaces(input)
+    self.assertEqual('This is a text with (incorrect whitespaces between brackets).', output)
+
+  def test_reformat_text(self):
+    input = u'''
+   أَخْبَرَنَا أَبُو جَعْفَرٍ مُحَمَّدُ بْنُ يَعْقُوبَ قَالَ حَدَّثَنِي عِدَّةٌ مِنْ أَصْحَابِنَا مِنْهُمْ مُحَمَّدُ بْنُ
+يَحْيَى الْعَطَّارُ عَنْ أَحْمَدَ بْنِ مُحَمَّدٍ عَنِ الْحَسَنِ بْنِ مَحْبُوبٍ عَنِ الْعَلَاءِ بْنِ رَزِينٍ عَنْ مُحَمَّدِ بْنِ مُسْلِمٍ
+عَنْ أَبِي جَعْفَرٍ ( عليه السلام )قَالَ لَمَّا خَلَقَ اللَّهُ الْعَقْلَ اسْتَنْطَقَهُ ثُمَّ قَالَ لَهُ أَقْبِلْ فَأَقْبَلَ ثُمَّ قَالَ لَهُ أَدْبِرْ
+فَأَدْبَرَ ثُمَّ قَالَ وَ عِزَّتِي وَ جَلَالِي مَا خَلَقْتُ خَلْقاً هُوَ أَحَبُّ إِلَيَّ مِنْكَ وَ لَا أَكْمَلْتُكَ إِلَّا فِيمَنْ
+أُحِبُّ أَمَا إِنِّي إِيَّاكَ آمُرُ وَ إِيَّاكَ أَنْهَى وَ إِيَّاكَ أُعَاقِبُ وَ إِيَّاكَ أُثِيبُ .
+    '''
+    output = reformat_text(input)
+    expected = u'''
+أَخْبَرَنَا أَبُو جَعْفَرٍ مُحَمَّدُ بْنُ يَعْقُوبَ قَالَ حَدَّثَنِي عِدَّةٌ مِنْ أَصْحَابِنَا مِنْهُمْ مُحَمَّدُ بْنُ يَحْيَى الْعَطَّارُ عَنْ أَحْمَدَ بْنِ مُحَمَّدٍ عَنِ الْحَسَنِ بْنِ مَحْبُوبٍ عَنِ الْعَلَاءِ بْنِ رَزِينٍ عَنْ مُحَمَّدِ بْنِ مُسْلِمٍ عَنْ أَبِي جَعْفَرٍ (عليه السلام)قَالَ لَمَّا خَلَقَ اللَّهُ الْعَقْلَ اسْتَنْطَقَهُ ثُمَّ قَالَ لَهُ أَقْبِلْ فَأَقْبَلَ ثُمَّ قَالَ لَهُ أَدْبِرْ فَأَدْبَرَ ثُمَّ قَالَ وَ عِزَّتِي وَ جَلَالِي مَا خَلَقْتُ خَلْقاً هُوَ أَحَبُّ إِلَيَّ مِنْكَ وَ لَا أَكْمَلْتُكَ إِلَّا فِيمَنْ أُحِبُّ أَمَا إِنِّي إِيَّاكَ آمُرُ وَ إِيَّاكَ أَنْهَى وَ إِيَّاكَ أُعَاقِبُ وَ إِيَّاكَ أُثِيبُ .
+    '''.strip()
+    self.assertEqual(expected, output)
+
+class ArabicTestCase(SimpleTestCase):
+  def test_remove_arabic_diactric(self):
+    input = 'اخْتِبار ازَاْلة عَلامات التَشْكيل'
+    output = remove_arabic_diactrictics(input)
+    self.assertEqual('اختبار ازالة علامات التشكيل', output)
+
+  def test_unify_alef_letters(self):
+    input = 'اآأإٱٲٳٵ'
+    output = unify_alef_letters(input)
+    self.assertEqual('اااااااا', output)


### PR DESCRIPTION
Like the reformat features in IDEs, this method is used to unify the
formats of hadith texts. For example, multi-line text gets converted
to single-line text; unnecessary whitespaces after opening brackets
and before closing brackets get removed, and so on.