### PR TITLE
chore(unicode): Use unicode encoding where necessary

### DIFF
--- a/HadithHouseWebsite/hadiths/tests.py
+++ b/HadithHouseWebsite/hadiths/tests.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from django.test import TestCase
 
 from hadiths.models import Person, Book, BookVolume, BookChapter, BookSection, HadithTag, Hadith
@@ -6,64 +8,64 @@ from hadiths.models import Person, Book, BookVolume, BookChapter, BookSection, H
 class PersonTestCase(TestCase):
   def test_pre_save(self):
     p = Person()
-    p.display_name = 'إخْتِبار إزَاْلة عَلامات التَشْكيل'
-    p.full_name = 'إخْتِبار إزَاْلة عَلامات التَشْكيل'
-    p.brief_desc = 'إخْتِبار إزَاْلة عَلامات التَشْكيل'
+    p.display_name = u'إخْتِبار إزَاْلة عَلامات التَشْكيل'
+    p.full_name = u'إخْتِبار إزَاْلة عَلامات التَشْكيل'
+    p.brief_desc = u'إخْتِبار إزَاْلة عَلامات التَشْكيل'
     p.save()
 
-    self.assertEqual('اختبار ازالة علامات التشكيل', p.simple_display_name)
-    self.assertEqual('اختبار ازالة علامات التشكيل', p.simple_full_name)
-    self.assertEqual('اختبار ازالة علامات التشكيل', p.simple_brief_desc)
+    self.assertEqual(u'اختبار ازالة علامات التشكيل', p.simple_display_name)
+    self.assertEqual(u'اختبار ازالة علامات التشكيل', p.simple_full_name)
+    self.assertEqual(u'اختبار ازالة علامات التشكيل', p.simple_brief_desc)
 
 
 class BookTestCase(TestCase):
   def test_pre_save(self):
     b = Book()
-    b.title = 'إخْتِبار إزَاْلة عَلامات التَشْكيل'
-    b.brief_desc = 'إخْتِبار إزَاْلة عَلامات التَشْكيل'
+    b.title = u'إخْتِبار إزَاْلة عَلامات التَشْكيل'
+    b.brief_desc = u'إخْتِبار إزَاْلة عَلامات التَشْكيل'
     b.save()
 
     bv = BookVolume()
     bv.number = 1
-    bv.title = 'إخْتِبار إزَاْلة عَلامات التَشْكيل'
+    bv.title = u'إخْتِبار إزَاْلة عَلامات التَشْكيل'
     bv.book = b
     bv.save()
 
     bc = BookChapter()
     bc.number = 1
-    bc.title = 'إخْتِبار إزَاْلة عَلامات التَشْكيل'
+    bc.title = u'إخْتِبار إزَاْلة عَلامات التَشْكيل'
     bc.book = b
     bc.save()
 
     bs = BookSection()
     bs.number = 1
-    bs.title = 'إخْتِبار إزَاْلة عَلامات التَشْكيل'
+    bs.title = u'إخْتِبار إزَاْلة عَلامات التَشْكيل'
     bs.book = b
     bs.save()
 
-    self.assertEqual('اختبار ازالة علامات التشكيل', b.simple_title)
-    self.assertEqual('اختبار ازالة علامات التشكيل', b.simple_brief_desc)
+    self.assertEqual(u'اختبار ازالة علامات التشكيل', b.simple_title)
+    self.assertEqual(u'اختبار ازالة علامات التشكيل', b.simple_brief_desc)
 
-    self.assertEqual('اختبار ازالة علامات التشكيل', bv.simple_title)
+    self.assertEqual(u'اختبار ازالة علامات التشكيل', bv.simple_title)
 
-    self.assertEqual('اختبار ازالة علامات التشكيل', bc.simple_title)
+    self.assertEqual(u'اختبار ازالة علامات التشكيل', bc.simple_title)
 
-    self.assertEqual('اختبار ازالة علامات التشكيل', bs.simple_title)
+    self.assertEqual(u'اختبار ازالة علامات التشكيل', bs.simple_title)
 
 
 class HadithTagTestCase(TestCase):
   def test_pre_save(self):
     p = HadithTag()
-    p.name = 'إخْتِبار إزَاْلة عَلامات التَشْكيل'
+    p.name = u'إخْتِبار إزَاْلة عَلامات التَشْكيل'
     p.save()
 
-    self.assertEqual('اختبار ازالة علامات التشكيل', p.simple_name)
+    self.assertEqual(u'اختبار ازالة علامات التشكيل', p.simple_name)
 
 
 class HadithTestCase(TestCase):
   def test_pre_save(self):
     p = Hadith()
-    p.text = 'إخْتِبار إزَاْلة عَلامات التَشْكيل'
+    p.text = u'إخْتِبار إزَاْلة عَلامات التَشْكيل'
     p.save()
 
-    self.assertEqual('اختبار ازالة علامات التشكيل', p.simple_text)
+    self.assertEqual(u'اختبار ازالة علامات التشكيل', p.simple_text)

--- a/HadithHouseWebsite/textprocessing/arabic.py
+++ b/HadithHouseWebsite/textprocessing/arabic.py
@@ -4,22 +4,22 @@ import re
 def remove_arabic_diacritics(input):
   if input is None:
     return None
-  return re.sub(u'[\u064B-\u0652]', '', input, flags=re.MULTILINE)
+  return re.sub(u'[\u064B-\u0652]', u'', input, flags=re.MULTILINE)
 
 
 def unify_alef_letters(input):
   if input is None:
     return None
   # Source: "Arabic script in Unicode" at Wikipedia
-  alef = '\u0627'
-  alef_with_madda = '\u0622'
-  alef_with_hamza = '\u0623'
-  alef_with_hamza_below = '\u0625'
-  alef_wasla = '\u0671'
-  alef_with_wavy_hamza = '\u0672'
-  alef_with_wavy_hamza_below = '\u0673'
-  alef_high_hamza_alef = '\u0675'
-  regex = '[' + ''.join([
+  alef = u'\u0627'
+  alef_with_madda = u'\u0622'
+  alef_with_hamza = u'\u0623'
+  alef_with_hamza_below = u'\u0625'
+  alef_wasla = u'\u0671'
+  alef_with_wavy_hamza = u'\u0672'
+  alef_with_wavy_hamza_below = u'\u0673'
+  alef_high_hamza_alef = u'\u0675'
+  regex = u'[' + u''.join([
     alef_with_madda,
     alef_with_hamza,
     alef_with_hamza_below,
@@ -27,7 +27,7 @@ def unify_alef_letters(input):
     alef_with_wavy_hamza,
     alef_with_wavy_hamza_below,
     alef_high_hamza_alef
-  ]) + ']'
+  ]) + u']'
   return re.sub(regex, alef, input, flags=re.MULTILINE)
 
 

--- a/HadithHouseWebsite/textprocessing/generic.py
+++ b/HadithHouseWebsite/textprocessing/generic.py
@@ -8,7 +8,7 @@ def multiline_to_singleline(text):
   :param text: The text to convert.
   :return: The single-line version of the text.
   """
-  return re.sub('\s+', ' ', text)
+  return re.sub(u'\s+', u' ', text)
 
 
 def remove_brackets_whitespaces(text):
@@ -18,7 +18,7 @@ def remove_brackets_whitespaces(text):
   :param text: The text to process.
   :return: The processed texts.
   """
-  return re.sub(r'\(\s*', '(', re.sub(r'\s*\)', ')', text))
+  return re.sub(r'\(\s*', u'(', re.sub(r'\s*\)', u')', text))
 
 
 def reformat_text(input):

--- a/HadithHouseWebsite/textprocessing/tests.py
+++ b/HadithHouseWebsite/textprocessing/tests.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from django.test import TestCase
 from django.test.testcases import SimpleTestCase
 
@@ -8,14 +10,14 @@ from textprocessing.regex import DocScanner
 
 class GenericTestCase(SimpleTestCase):
   def test_multiline_to_singleline(self):
-    input = 'My name is \n  Rafid \r Khalid'
+    input = u'My name is \n  Rafid \r Khalid'
     output = multiline_to_singleline(input)
-    self.assertEqual('My name is Rafid Khalid', output)
+    self.assertEqual(u'My name is Rafid Khalid', output)
 
   def test_remove_brackets_whitespaces(self):
-    input = 'This is a text with (  incorrect whitespaces between brackets   ).'
+    input = u'This is a text with (  incorrect whitespaces between brackets   ).'
     output = remove_brackets_whitespaces(input)
-    self.assertEqual('This is a text with (incorrect whitespaces between brackets).', output)
+    self.assertEqual(u'This is a text with (incorrect whitespaces between brackets).', output)
 
   def test_reformat_text(self):
     input = u'''
@@ -34,31 +36,31 @@ class GenericTestCase(SimpleTestCase):
 
 class ArabicTestCase(SimpleTestCase):
   def test_remove_arabic_diacritic(self):
-    input = 'اخْتِبار ازَاْلة عَلامات التَشْكيل'
+    input = u'اخْتِبار ازَاْلة عَلامات التَشْكيل'
     output = remove_arabic_diacritics(input)
-    self.assertEqual('اختبار ازالة علامات التشكيل', output)
+    self.assertEqual(u'اختبار ازالة علامات التشكيل', output)
 
   def test_unify_alef_letters(self):
-    input = 'اآأإٱٲٳٵ'
+    input = u'اآأإٱٲٳٵ'
     output = unify_alef_letters(input)
-    self.assertEqual('اااااااا', output)
+    self.assertEqual(u'اااااااا', output)
 
   def test_simplify_arabic_text_for_surat_alfatiha(self):
-    self.assertEqual('بسم الله الرحمن الرحيم', simplify_arabic_text('بِسْمِ اللَّهِ الرَّحْمَنِ الرَّحِيمِ'))
-    self.assertEqual('الحمد لله رب العالمين', simplify_arabic_text('الْحَمْدُ لِلَّهِ رَبِّ الْعَالَمِينَ'))
-    self.assertEqual('الرحمن الرحيم', simplify_arabic_text('الرَّحْمَنِ الرَّحِيمِ'))
-    self.assertEqual('مالك يوم الدين', simplify_arabic_text('مَالِكِ يَوْمِ الدِّينِ'))
-    self.assertEqual('اياك نعبد واياك نستعين', simplify_arabic_text('إِيَّاكَ نَعْبُدُ وَإِيَّاكَ نَسْتَعِينُ'))
-    self.assertEqual('اهدنا الصراط المستقيم', simplify_arabic_text('اهدِنَا الصِّرَاطَ الْمُسْتَقِيمَ'))
-    self.assertEqual('صراط الذين انعمت عليهم غير المغضوب عليهم ولا الضالين', simplify_arabic_text(
-      'صِرَاطَ الَّذِينَ أَنْعَمْتَ عَلَيْهِمْ غَيْرِ الْمَغْضُوبِ عَلَيْهِمْ وَلاَ الضَّالِّينَ'))
+    self.assertEqual(u'بسم الله الرحمن الرحيم', simplify_arabic_text(u'بِسْمِ اللَّهِ الرَّحْمَنِ الرَّحِيمِ'))
+    self.assertEqual(u'الحمد لله رب العالمين', simplify_arabic_text(u'الْحَمْدُ لِلَّهِ رَبِّ الْعَالَمِينَ'))
+    self.assertEqual(u'الرحمن الرحيم', simplify_arabic_text(u'الرَّحْمَنِ الرَّحِيمِ'))
+    self.assertEqual(u'مالك يوم الدين', simplify_arabic_text(u'مَالِكِ يَوْمِ الدِّينِ'))
+    self.assertEqual(u'اياك نعبد واياك نستعين', simplify_arabic_text(u'إِيَّاكَ نَعْبُدُ وَإِيَّاكَ نَسْتَعِينُ'))
+    self.assertEqual(u'اهدنا الصراط المستقيم', simplify_arabic_text(u'اهدِنَا الصِّرَاطَ الْمُسْتَقِيمَ'))
+    self.assertEqual(u'صراط الذين انعمت عليهم غير المغضوب عليهم ولا الضالين', simplify_arabic_text(
+      u'صِرَاطَ الَّذِينَ أَنْعَمْتَ عَلَيْهِمْ غَيْرِ الْمَغْضُوبِ عَلَيْهِمْ وَلاَ الضَّالِّينَ'))
 
   def test_simplify_arabic_text_for_different_alef_types(self):
     # TODO: Add tests for the rest of Alef types.
-    self.assertEqual('امنا', simplify_arabic_text('آمَنَّا'))
-    self.assertEqual('اولئك', simplify_arabic_text('أُوْلَئِكَ'))
-    self.assertEqual('او', simplify_arabic_text('أَوْ'))
-    self.assertEqual('واذا', simplify_arabic_text('وَإِذَا'))
+    self.assertEqual(u'امنا', simplify_arabic_text(u'آمَنَّا'))
+    self.assertEqual(u'اولئك', simplify_arabic_text(u'أُوْلَئِكَ'))
+    self.assertEqual(u'او', simplify_arabic_text(u'أَوْ'))
+    self.assertEqual(u'واذا', simplify_arabic_text(u'وَإِذَا'))
     pass
 
 


### PR DESCRIPTION
- If non-ASCII code exists in a file, use the following header:
```
"# -*- coding: utf-8 -*-"
```
- If a string contains non-ASCII code, prefix it with 'u'.