### PR TITLE
feat(bnd): Move some steps from deploy.sh to build.sh

### DIFF
--- a/HadithHouseWebsite/build.sh
+++ b/HadithHouseWebsite/build.sh
@@ -1,2 +1,24 @@
+#!/bin/bash
+
+SERVER_SETTINGS_PATH='/home/jenkins'
+LOGS_PATH='/var/log/hadithhouse'
+
+# Stops the execution of the script if any command, including pipes, fail.
+set -e 
+set -o pipefail
+
+# Create the logs directory if it is not created
+echo "Creating the logs directory if it is not created"
+mkdir -p $LOGS_PATH
+
+# Copy server settings file into te build directory.
+echo "Copy server_settings.py from $SERVER_SETTINGS_PATH to `pwd`/HadithHouseWebsite/"
+cp ${SERVER_SETTINGS_PATH}/server_settings.py HadithHouseWebsite/
+
+# Collect Django's static files.
+echo "Running manage.py collectstatic to collect static files."
+python manage.py collectstatic --noinput
+
+# Running tests...
 echo "Running tests..."
 python manage.py test

--- a/HadithHouseWebsite/deploy.sh
+++ b/HadithHouseWebsite/deploy.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-SERVER_SETTINGS_PATH='/home/jenkins'
 DEPLOYMENT_PATH='/var/www/hadithhouse'
-LOGS_PATH='/var/log/hadithhouse'
 
 # Stops the execution of the script if any command, including pipes, fail.
 set -e 
@@ -11,18 +9,6 @@ set -o pipefail
 # Deleting the current files in the deployment directory.
 echo "Deleting ${DEPLOYMENT_PATH}"
 rm -rf ${DEPLOYMENT_PATH}/*
-
-# Create the logs directory if it is not created
-echo "Creating the logs directory if it is not created"
-mkdir -p $LOGS_PATH
-
-# Copy server settings file into te build directory.
-echo "Copy server_settings.py from $SERVER_SETTINGS_PATH to `pwd`/HadithHouseWebsite/"
-cp ${SERVER_SETTINGS_PATH}/server_settings.py HadithHouseWebsite/
-
-# Collect Django's static files.
-echo "Running manage.py collectstatic to collect static files."
-python manage.py collectstatic --noinput
 
 # Apply Django's migrations.
 echo "Running manage.py migrate to apply migrations."


### PR DESCRIPTION
Some steps which were in deploy.sh were moved to build.sh. Examples of
such steps are the copying of server_settings.py file and the creation
of log directories which is a required step before we can execute the
code.