### PR TITLE
fix(build): Fixing a bug causing tests to fail using Python 2

### DIFF
--- a/HadithHouseWebsite/textprocessing/arabic.py
+++ b/HadithHouseWebsite/textprocessing/arabic.py
@@ -1,10 +1,10 @@
 import re
 
 PUNCTUATION_MARKS = (
-  '\u061f',  # Question mark
-  '!',
-  '\u060c',  # Comma
-  '.'
+  u'\u061f',  # Question mark
+  u'!',
+  u'\u060c',  # Comma
+  u'.'
 )
 
 


### PR DESCRIPTION
The `PUNCTUATION_MARKS` in `arabic.py` module didn't have the 'u'
prefix, which caused the test below to fail on Jenkins:

test_remove_punctuation_marks_whitespaces_arabic