### PR TITLE
fix(build): Remove socketserver import from settings.py

### DIFF
--- a/HadithHouseWebsite/HadithHouseWebsite/settings.py
+++ b/HadithHouseWebsite/HadithHouseWebsite/settings.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/1.7/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 import socket
-import socketserver
 
 import sys
 


### PR DESCRIPTION
This import is SocketServer in Python 2 and socketserver in Python 3,
and so it was causing the build to fail.