### PR TITLE
fix(bnd): Move logs creation from build.sh to deploy.sh

### DIFF
--- a/HadithHouseWebsite/build.sh
+++ b/HadithHouseWebsite/build.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
 
 SERVER_SETTINGS_PATH='/home/jenkins'
-LOGS_PATH='/var/log/hadithhouse'
 
 # Stops the execution of the script if any command, including pipes, fail.
 set -e 
 set -o pipefail
-
-# Create the logs directory if it is not created
-echo "Creating the logs directory if it is not created"
-mkdir -p $LOGS_PATH
 
 # Copy server settings file into te build directory.
 echo "Copy server_settings.py from $SERVER_SETTINGS_PATH to `pwd`/HadithHouseWebsite/"

--- a/HadithHouseWebsite/deploy.sh
+++ b/HadithHouseWebsite/deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DEPLOYMENT_PATH='/var/www/hadithhouse'
+LOGS_PATH='/var/log/hadithhouse'
 
 # Stops the execution of the script if any command, including pipes, fail.
 set -e 
@@ -21,6 +22,10 @@ mkdir -p $DEPLOYMENT_PATH
 # Copy the project onto the deployment directory.
 echo "Copying `pwd`/* to $DEPLOYMENT_PATH"
 cp -r ./* ${DEPLOYMENT_PATH}/
+
+# Create the logs directory if it is not created
+echo "Creating the logs directory if it is not created"
+mkdir -p $LOGS_PATH
 
 # Give Apache2 ownership of the log files so it can write to them.
 echo "Give Apache2 ownership of the log files so it can write to them."


### PR DESCRIPTION
Logs directory should not be part of the build step anyway, but in
addition to that, it makes the build.sh file requires some sudo
permission.