### PR TITLE
fix(bnd): Few fixes in settings.py

### DIFF
--- a/HadithHouseWebsite/HadithHouseWebsite/settings.py
+++ b/HadithHouseWebsite/HadithHouseWebsite/settings.py
@@ -14,8 +14,17 @@ import socket
 
 import sys
 
-from HadithHouseWebsite.server_settings import get_db_settings, get_debug, get_allowed_hosts, \
-  get_log_dir
+from HadithHouseWebsite.server_settings import get_db_settings, get_debug, get_allowed_hosts
+
+if len(set(['test', 'collectstatic']) & set(sys.argv)) > 0:
+  # We are running in test mode or collecting static files. Hence, avoid using
+  # the real log directory to avoid breaking Jenkins build, as there is no
+  # log directory on Jenkins.
+  import tempfile
+  def get_log_dir():
+    return tempfile.gettempdir()
+else:
+  from HadithHouseWebsite.server_settings import get_log_dir
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 

--- a/HadithHouseWebsite/build.sh
+++ b/HadithHouseWebsite/build.sh
@@ -8,8 +8,8 @@ set -o pipefail
 # The SERVER_SETTINGS_FILE environment variable should be defined in Jenkins
 # after uploading the settings file using the Config File Provider plugin:
 # https://wiki.jenkins-ci.org/display/JENKINS/Config+File+Provider+Plugin
-echo "Copy server settings  from $SERVER_SETTINGS_PATH to `pwd`/HadithHouseWebsite/"
-cp ${SERVER_SETTINGS_PATH} HadithHouseWebsite/server_settings.py
+echo "Copy server settings  from $SERVER_SETTINGS_PATH to `pwd`/HadithHouseWebsite/server_settings.py"
+cp "${SERVER_SETTINGS_PATH}" "HadithHouseWebsite/server_settings.py"
 
 # Install Nodejs packages.
 npm install


### PR DESCRIPTION
- Surround paths in call to 'cp' command with double quotes
- Return temp directory in get_log_dir() during tests