### PR TITLE
fix(build): Add sqlparse to requirements.txt

### DIFF
--- a/HadithHouseWebsite/requirements.txt
+++ b/HadithHouseWebsite/requirements.txt
@@ -3,4 +3,5 @@ django-crispy-forms==1.6.0
 django-filter==0.12.0
 djangorestframework==3.3.2
 psycopg2==2.6.1
+sqlparse==0.2.2
 urlfetch==1.0.2


### PR DESCRIPTION
After adding the following migration while working on #228:

```python
migrations.RunSQL('''
CREATE INDEX hadiths_text_idx ON hadiths USING GIN (TO_TSVECTOR('english', text));
CREATE INDEX hadiths_simpletext_idx ON hadiths USING GIN (TO_TSVECTOR('english', simple_text));
''')
```

build on Jenkins started failing with the following error:

```
django.core.exceptions.ImproperlyConfigured: sqlparse is required if you don't split your SQL statements manually.
```

I checked Django's code and found the following code in
`django/db/backends/base/operations.py` that is throwing this exception:

```python
    def prepare_sql_script(self, sql):
        """
        Takes an SQL script that may contain multiple lines and returns a list
        of statements to feed to successive cursor.execute() calls.
        Since few databases are able to process raw SQL scripts in a single
        cursor.execute() call and PEP 249 doesn't talk about this use case,
        the default implementation is conservative.
        """
        try:
            import sqlparse
        except ImportError:
            raise ImproperlyConfigured(
                "sqlparse is required if you don't split your SQL "
                "statements manually."
            )
        else:
            return [sqlparse.format(statement, strip_comments=True)
                    for statement in sqlparse.split(sql) if statement]
```

Hence why I added `sqlparse` to `requirements.txt`