### PR TITLE
fix(build): Disable running migration to create index during test

### DIFF
--- a/HadithHouseWebsite/HadithHouseWebsite/settings.py
+++ b/HadithHouseWebsite/HadithHouseWebsite/settings.py
@@ -16,11 +16,13 @@ import sys
 
 from HadithHouseWebsite.server_settings import get_db_settings, get_debug, get_allowed_hosts
 
-if len(set(['test', 'collectstatic']) & set(sys.argv)) > 0:
+if len({'test', 'collectstatic'} & set(sys.argv)) > 0:
   # We are running in test mode or collecting static files. Hence, avoid using
   # the real log directory to avoid breaking Jenkins build, as there is no
   # log directory on Jenkins.
   import tempfile
+
+
   def get_log_dir():
     return tempfile.gettempdir()
 else:
@@ -48,6 +50,7 @@ DEVELOPMENT_HOSTS = (
   'www.hadithhouse-dev.net',
 )
 
+
 def get_environment():
   host = socket.getfqdn().lower()
 
@@ -57,6 +60,7 @@ def get_environment():
     return 'development'
   else:
     return 'local'
+
 
 SERVER_EMAIL = 'noreply@hadithhouse.net'
 

--- a/HadithHouseWebsite/hadiths/migrations/0005_create_fulltextsearch_index.py
+++ b/HadithHouseWebsite/hadiths/migrations/0005_create_fulltextsearch_index.py
@@ -1,8 +1,6 @@
-from django.db import migrations
-from django.db.transaction import atomic
+import sys
 
-from hadiths.initial_data import *
-from hadiths.models import Person, Hadith, HadithTag, Chain, ChainPersonRel, Book, HadithTagRel
+from django.db import migrations
 
 
 class Migration(migrations.Migration):
@@ -10,9 +8,12 @@ class Migration(migrations.Migration):
     ('hadiths', '0004_add_first_hadiths'),
   ]
 
-  operations = [
-    migrations.RunSQL('''
-CREATE INDEX hadiths_text_idx ON hadiths USING GIN (TO_TSVECTOR('english', text));
-CREATE INDEX hadiths_simpletext_idx ON hadiths USING GIN (TO_TSVECTOR('english', simple_text));
-''')
-  ]
+  if len({'test'} & set(sys.argv)) > 0:
+    operations = ()
+  else:
+    operations = [
+      migrations.RunSQL('''
+  CREATE INDEX hadiths_text_idx ON hadiths USING GIN (TO_TSVECTOR('english', text));
+  CREATE INDEX hadiths_simpletext_idx ON hadiths USING GIN (TO_TSVECTOR('english', simple_text));
+  ''')
+    ]


### PR DESCRIPTION
While working on #228, a migration was added to create an index for
`text` and `simple_text` fields of `Hadith` model. In addition to the
type of the index being specific to Postgres (GIN index), which
caused the build to fail because a test database doesn't support this
type of index, it is not a good idea to have an index during test.
This commit add an if condition to not run that migration during test
mode.