### PR TITLE
fix(test) Install `mock` library from `pip`

### DIFF
--- a/HadithHouseWebsite/hadiths/tests/tests_hadithtagapi.py
+++ b/HadithHouseWebsite/hadiths/tests/tests_hadithtagapi.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from mock import patch
 
 from django.test import Client
 from django.test import TestCase

--- a/HadithHouseWebsite/requirements.txt
+++ b/HadithHouseWebsite/requirements.txt
@@ -2,6 +2,7 @@ Django==1.9.3
 django-crispy-forms==1.6.0
 django-filter==0.12.0
 djangorestframework==3.3.2
+mock==2.0.0
 psycopg2==2.6.1
 sqlparse==0.2.2
 urlfetch==1.0.2


### PR DESCRIPTION
unittest.mock exists only in Python 3.3+ and as such the build was
broken. To keep the project python-compatible, I am installing
the `mock` library from `pip` instead of depending on the built-in
one.

Issue #245