### PR TITLE
chore(python-packs) Upgrade Python packages

### DIFF
--- a/HadithHouseWebsite/requirements.txt
+++ b/HadithHouseWebsite/requirements.txt
@@ -1,8 +1,8 @@
-Django==1.9.3
-django-crispy-forms==1.6.0
-django-filter==0.12.0
-djangorestframework==3.3.2
+Django==1.10.3
+django-crispy-forms==1.6.1
+django-filter==0.15.3
+djangorestframework==3.5.3
 mock==2.0.0
-psycopg2==2.6.1
+psycopg2==2.6.2
 sqlparse==0.2.2
 urlfetch==1.0.2


### PR DESCRIPTION
* Django from 1.9.3 to 1.10.3
* django-crispy-forms from 1.6.0 to 1.6.1
* django-filter from 0.12.0 to 0.15.3
* djangorestframework from 3.3.2 to 3.5.3
* psycopg2 from 2.6.1 to 2.6.2