### PR TITLE
feat(hadiths) Add a service to retrieve a random untagged hadith

### DIFF
--- a/HadithHouseWebsite/hadiths/apiviews.py
+++ b/HadithHouseWebsite/hadiths/apiviews.py
@@ -9,7 +9,8 @@ from rest_framework.status import HTTP_403_FORBIDDEN
 
 from hadiths.fbauthapiviews import FBAuthListCreateAPIView, FBAuthRetrieveUpdateDestroyAPIView
 from hadiths.filters import TagsFilter, IdsFilter
-from hadiths.models import Hadith, Person, Book, HadithTag, User, Chain, BookVolume, BookChapter, BookSection
+from hadiths.models import Hadith, Person, Book, HadithTag, User, Chain, BookVolume, BookChapter, BookSection, \
+  HadithTagRel
 from hadiths.serializers import HadithSerializer, PersonSerializer, BookSerializer, HadithTagSerializer, \
   UserSerializer, ChainSerializer, BookVolumeSerializer, BookChapterSerializer, BookSectionSerializer
 
@@ -228,6 +229,13 @@ class HadithView(FBAuthRetrieveUpdateDestroyAPIView):
       random_index = randint(0, count - 1)
       random_hadith = Hadith.objects.all()[random_index]
       serializer = self.get_serializer(random_hadith)
+      return Response(serializer.data)
+    elif id == 'randomuntagged':
+      query = Hadith.objects.exclude(id__in = HadithTagRel.objects.values_list('hadith_id', flat=True))
+      count = query.aggregate(count=Count('id'))['count']
+      random_index = randint(0, count - 1)
+      random_untagged_hadith = query[random_index]
+      serializer = self.get_serializer(random_untagged_hadith)
       return Response(serializer.data)
     else:
       return super(HadithView, self).get(request, *args, **kwargs)

--- a/HadithHouseWebsite/hadiths/urls.py
+++ b/HadithHouseWebsite/hadiths/urls.py
@@ -19,7 +19,7 @@ urlpatterns = [
   url(r'^apis/hadithtags/?$', apiviews.HadithTagSetView.as_view()),
   url(r'^apis/hadithtags/(?P<id>\w+)$', apiviews.HadithTagView.as_view()),
   url(r'^apis/hadiths/?$', apiviews.HadithSetView.as_view()),
-  url(r'^apis/hadiths/(?P<id>([0-9]+|random))$', apiviews.HadithView.as_view()),
+  url(r'^apis/hadiths/(?P<id>([0-9]+|random|randomuntagged))$', apiviews.HadithView.as_view()),
   url(r'^apis/chains/?$', apiviews.ChainSetView.as_view()),
   url(r'^apis/chains/(?P<id>[0-9]+)$', apiviews.ChainView.as_view()),
   url(r'^apis/users/?$', apiviews.UserSetView.as_view()),


### PR DESCRIPTION
This will be used to display a random untagged hadith in the website
to encourage users to tag them.

The method to find a random untagged hadith is to find a hadith whose
ID is not in the `HadithTagRel` model. This is the query that does
this (which was generated by Django):
```
SELECT "hadiths"."id",
  "hadiths"."text",
  "hadiths"."simple_text",
  "hadiths"."person_id",
  "hadiths"."book_id",
  "hadiths"."volume_id",
  "hadiths"."chapter_id",
  "hadiths"."section_id",
  "hadiths"."number",
  "hadiths"."added_on",
  "hadiths"."updated_on",
  "hadiths"."added_by_id",
  "hadiths"."updated_by_id"
FROM "hadiths"
WHERE NOT ("hadiths"."id" IN (SELECT U0."hadith_id" FROM "hadiths_hadithtags" U0)) LIMIT 1 OFFSET <Random Offset>;
```
This query is very expensive because it has to scan both `hadiths`
and `hadiths_hadithtags` tables. Adding salt to injury, to be able to
find a random offset, we need to execute this query with a count
aggregate to find the total count of untagged records, then find a
random offset.

So while it is a good quick implementation for this feature, once the
data and usage grow bigger, we might need to change this query.

Issue #159