### PR TITLE
chore(angular) Use ng-cloak in the HTML body

### DIFF
--- a/HadithHouseWebsite/hadiths/templates/hadiths/index.html
+++ b/HadithHouseWebsite/hadiths/templates/hadiths/index.html
@@ -23,7 +23,7 @@
   </style>
 </head>
 
-<body ng-controller="HadithHouseCtrl as ctrl">
+<body ng-controller="HadithHouseCtrl as ctrl" ng-cloak="">
 
 
 


### PR DESCRIPTION
To stop Angular templates from getting displayed before rendering.

Close #308