### PR TITLE
fix(tags-input) Fix a bug causing tags-input to show empty results

### DIFF
--- a/HadithHouseWebsite/hadiths/static/hadiths/js/controllers/hadith-page.ts
+++ b/HadithHouseWebsite/hadiths/static/hadiths/js/controllers/hadith-page.ts
@@ -157,7 +157,7 @@ module HadithHouse.Controllers {
       } else {
         this.personExpanded = null;
       }
-      if (this.bookExpanded) {
+      if (this.entity.book) {
         this.bookExpanded = this.BookResource.get([this.entity.book]);
       } else {
         this.bookExpanded = null;

--- a/HadithHouseWebsite/hadiths/static/hadiths/js/directives/tags-input.directive.ts
+++ b/HadithHouseWebsite/hadiths/static/hadiths/js/directives/tags-input.directive.ts
@@ -65,7 +65,9 @@ module HadithHouse.Directives {
       if (!this.selectionMode) {
         this.selectionMode = 'multi';
       }
-      this.entities = [];
+      if (!this.entities) {
+        this.entities = [];
+      }
       this.$scope.$watch(() => this.text, (newText, oldText) => {
         if (this.text && this.text.length > 2) {
           this.findEntities(this.text).promise.then((result) => {


### PR DESCRIPTION
This problem happens if the `entities` attribute passed to the
`tags-input` directive already contain valid data but get overridden
by `tags-input` in the following code:
```
this.entities = [];
```
The solution was to change it check if it contains some value first:
```
if (!this.entities) {
  this.entities = [];
}
```

#316