### PR TITLE
fix(build) Fix the version of typescript and grunt-tsc

### DIFF
--- a/HadithHouseWebsite/package.json
+++ b/HadithHouseWebsite/package.json
@@ -12,7 +12,8 @@
     "grunt": "^1.0.1",
     "grunt-contrib-cssmin": "^1.0.2",
     "grunt-contrib-uglify": "^2.0.0",
-    "grunt-ts": "^6.0.0-beta.3"
+    "grunt-ts": "6.0.0-beta.3",
+    "typescript": "2.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The build started failing recently because the recent beta version(s)
of grunt 6.0.0 started referencing a newer version of typescript, so
I fixed the version of grunt-tsc and added a refrenece to "typescript"
npm package version 2.2.0.