### PR TITLE
fix(resource) Fix misuse of cache in resource.ts

### DIFF
--- a/HadithHouseWebsite/hadiths/static/hadiths/js/caching/cache.ts
+++ b/HadithHouseWebsite/hadiths/static/hadiths/js/caching/cache.ts
@@ -59,6 +59,9 @@ export class Cache<TObject> {
    * @param cachingPeriod The caching period in minutes.
    */
   public put(key: string, object: TObject, cachingPeriod: number = this.defaultCachingPeriod) {
+    if (key === null || typeof(key) === 'undefined') {
+      throw "Parameter 'key' cannot be null or undefined.";
+    }
     let entry = new CacheEntry<TObject>();
     entry.key = key.toString();
     entry.expiryTime = moment().add(cachingPeriod, 'minutes');
@@ -74,8 +77,11 @@ export class Cache<TObject> {
    * cached or it has expired.
    */
   public get(key: string, returnsExpired = true): TObject {
+    if (key === null || typeof(key) === 'undefined') {
+      throw "Parameter 'key' cannot be null or undefined.";
+    }
     let entry = this.objectDict[key.toString()];
-    if (!entry || (entry.isExpired() && !returnsExpired)) {
+    if (!entry || (entry.isExpired() && returnsExpired !== true)) {
       return null;
     }
     return entry.object;

--- a/HadithHouseWebsite/hadiths/static/hadiths/js/resources/resources.ts
+++ b/HadithHouseWebsite/hadiths/static/hadiths/js/resources/resources.ts
@@ -389,7 +389,7 @@ export class CacheableResource<TEntity extends Entity<TId>, TId> {
         // for the same object won't have to go to the RESTful API again.
         entity = this.create();
         entity.id = id;
-        this.cache.put(entity.toString(), entity);
+        this.cache.put(entity.id.toString(), entity);
         idsOfEntitiesToFetch.push(id);
         entities.push(entity);
 


### PR DESCRIPTION
The function `getByMultipleIdsWithCache` was passing `entity.toString()` to `Cache.put` function instead of `entity.id.toString()`, which caused the `Cache.put` function to fail.

I also added pre-checks to `Cache.get` and `Cache.put` functions so it is obvious in the future if an error is caused by sending a `null`/`undefined` key to those functions.

Close #333